### PR TITLE
Missing license for PInvoke.BCrypt/0.5.184

### DIFF
--- a/curations/nuget/nuget/-/PInvoke.BCrypt.yaml
+++ b/curations/nuget/nuget/-/PInvoke.BCrypt.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: PInvoke.BCrypt
+  provider: nuget
+  type: nuget
+revisions:
+  0.5.184:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Missing license for PInvoke.BCrypt/0.5.184

**Details:**
Adding license, which currently shows as "No Assertion".

**Resolution:**
Source:
https://github.com/AArnott/pinvoke/tree/cf0176c42bc63ddb8622f60c9fbd7176e7757bd3
MIT License:
Copyright (c) 2018 All contributors
https://github.com/AArnott/pinvoke/blob/cf0176c42bc63ddb8622f60c9fbd7176e7757bd3/LICENSE

**Affected definitions**:
- [PInvoke.BCrypt 0.5.184](https://clearlydefined.io/definitions/nuget/nuget/-/PInvoke.BCrypt/0.5.184/0.5.184)