### PR TITLE
submitted the source location 

### DIFF
--- a/curations/pypi/pypi/-/psycopg2-binary.yaml
+++ b/curations/pypi/pypi/-/psycopg2-binary.yaml
@@ -1,0 +1,14 @@
+coordinates:
+  name: psycopg2-binary
+  provider: pypi
+  type: pypi
+revisions:
+  2.8.2:
+    described:
+      sourceLocation:
+        name: psycopg2
+        namespace: psycopg
+        provider: github
+        revision: 324cded1661995cc006e04e2c5e6b00e61ab74ba
+        type: git
+        url: 'https://github.com/psycopg/psycopg2/commit/324cded1661995cc006e04e2c5e6b00e61ab74ba'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
submitted the source location 

**Details:**
The source repository was missing

**Resolution:**
Submitted the github path for 2.8.2 version of psycopg2 compponent.
https://github.com/psycopg/psycopg2/commit/324cded1661995cc006e04e2c5e6b00e61ab74ba

**Affected definitions**:
- [psycopg2-binary 2.8.2](https://clearlydefined.io/definitions/pypi/pypi/-/psycopg2-binary/2.8.2/2.8.2)