### PR TITLE
License information

### DIFF
--- a/curations/git/github/actframework/actframework.yaml
+++ b/curations/git/github/actframework/actframework.yaml
@@ -1,0 +1,38 @@
+coordinates:
+  name: actframework
+  namespace: actframework
+  provider: github
+  type: git
+revisions:
+  e09438ddc29ab34fc95e736f8052e9f9151385cf:
+    files:
+      - attributions:
+          - Copyright (c) 2014 - 2018 ActFramework
+          - Copyright (c) 2007-2010 Julio Vilmar Gesser.
+          - 'Copyright (c) 2011, 2013-2016 The JavaParser Team.'
+        license: LGPL-3.0-or-later OR Apache-2.0
+        path: src/main/java/act/apidoc/javadoc/JavadocBlockTag.java
+      - attributions:
+          - Copyright (c) 2014 - 2018 ActFramework
+          - Copyright (c) 2007-2010 Julio Vilmar Gesser.
+          - 'Copyright (c) 2011, 2013-2016 The JavaParser Team.'
+        license: LGPL-3.0-or-later OR Apache-2.0
+        path: src/main/java/act/apidoc/javadoc/JavadocDescription.java
+      - attributions:
+          - Copyright (c) 2014 - 2018 ActFramework
+          - Copyright (c) 2007-2010 Julio Vilmar Gesser.
+          - 'Copyright (c) 2011, 2013-2016 The JavaParser Team.'
+        license: LGPL-3.0-or-later OR Apache-2.0
+        path: src/main/java/act/apidoc/javadoc/JavadocDescriptionElement.java
+      - attributions:
+          - Copyright (c) 2014 - 2018 ActFramework
+          - Copyright (c) 2007-2010 Julio Vilmar Gesser.
+          - 'Copyright (c) 2011, 2013-2017 The JavaParser Team.'
+        license: LGPL-3.0-or-later OR Apache-2.0
+        path: src/main/java/act/apidoc/javadoc/JavadocInlineTag.java
+      - attributions:
+          - Copyright (c) 2014 - 2018 ActFramework
+          - Copyright (c) 2007-2010 Julio Vilmar Gesser.
+          - 'Copyright (c) 2011, 2013-2016 The JavaParser Team.'
+        license: LGPL-3.0-or-later OR Apache-2.0
+        path: src/main/java/act/apidoc/javadoc/JavadocSnippet.java


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
License information

**Details:**
The following files are found to be under wrong license information.

FolderPath: /actframework/src/main/java/act/apidoc/javadoc/

Affected Files:
a.	JavadocBlockTag.java
b.	JavadocDescriptionElement.java
c.	JavadocDescription.java
d.	JavadocSnippet.java
e.	JavadocInlineTag.jav

**Resolution:**
Updated license information to "LGPL-3.0-or-later OR Apache-2.0" instead of "Apache-2.0 AND GPL-1.0-or-later AND LGPL-2.0-or-later"

No evidence of GPL-1.0-or-later, LGPL-2.0-or-later found in those files.

**Affected definitions**:
- [actframework e09438ddc29ab34fc95e736f8052e9f9151385cf](https://clearlydefined.io/definitions/git/github/actframework/actframework/e09438ddc29ab34fc95e736f8052e9f9151385cf/e09438ddc29ab34fc95e736f8052e9f9151385cf)