### PR TITLE
PATENT files from golang.org contains patent license from Google

### DIFF
--- a/curations/git/github/kubernetes-sigs/controller-runtime.yaml
+++ b/curations/git/github/kubernetes-sigs/controller-runtime.yaml
@@ -1,0 +1,18 @@
+coordinates:
+  name: controller-runtime
+  namespace: kubernetes-sigs
+  provider: github
+  type: git
+revisions:
+  12d98582e72927b6cd0123e2b4e819f9341ce62c:
+    files:
+      - license: OTHER
+        path: vendor/golang.org/x/crypto/PATENTS
+      - license: OTHER
+        path: vendor/golang.org/x/net/PATENTS
+      - license: OTHER
+        path: vendor/golang.org/x/sys/PATENTS
+      - license: OTHER
+        path: vendor/golang.org/x/text/PATENTS
+      - license: OTHER
+        path: vendor/golang.org/x/time/PATENTS


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
PATENT files from golang.org contains patent license from Google

**Details:**
License found under /vendor/golang.org/x/*/PATENTS has been marked as NOASSERTION by ClearlyDefined. But, current analysis shows that it is the patent license granted by Google.

**Resolution:**
Changed the license name in all the appropriate files to "OTHER".

**Affected definitions**:
- [controller-runtime 12d98582e72927b6cd0123e2b4e819f9341ce62c](https://clearlydefined.io/definitions/git/github/kubernetes-sigs/controller-runtime/12d98582e72927b6cd0123e2b4e819f9341ce62c/12d98582e72927b6cd0123e2b4e819f9341ce62c)