### PR TITLE
Appending file level license

### DIFF
--- a/curations/git/github/apache/kafka.yaml
+++ b/curations/git/github/apache/kafka.yaml
@@ -1,0 +1,12 @@
+coordinates:
+  name: kafka
+  namespace: apache
+  provider: github
+  type: git
+revisions:
+  21234bee31165527859b46ea48c46b76532f7a37:
+    files:
+      - attributions:
+          - Copyright (c) 2004-2006 Intel Corporation
+        license: Apache-2.0 AND 0BSD
+        path: clients/src/main/java/org/apache/kafka/common/utils/PureJavaCrc32C.java


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Appending file level license

**Details:**
In the file "PureJavaCrc32C.java", code snippets from Intel Corp have been implemented (under BSD license)

**Resolution:**
Added 0BSD license to file "PureJavaCrc32C.java"

https://github.com/apache/kafka/blob/21234bee31165527859b46ea48c46b76532f7a37/clients/src/main/java/org/apache/kafka/common/utils/PureJavaCrc32C.java

**Affected definitions**:
- [kafka 21234bee31165527859b46ea48c46b76532f7a37](https://clearlydefined.io/definitions/git/github/apache/kafka/21234bee31165527859b46ea48c46b76532f7a37/21234bee31165527859b46ea48c46b76532f7a37)