### PR TITLE
Incorrect SPDX Identifier

### DIFF
--- a/curations/git/github/stuk/jszip.yaml
+++ b/curations/git/github/stuk/jszip.yaml
@@ -1,0 +1,35 @@
+coordinates:
+  name: jszip
+  namespace: stuk
+  provider: github
+  type: git
+revisions:
+  265c959b1f15f8cd5ebe152154b88796e4a82f42:
+    files:
+      - license: MIT OR GPL-3.0-only
+        path: bower.json
+      - license: MIT OR GPL-3.0-only
+        path: component.json
+      - license: MIT OR GPL-3.0-only
+        path: index.html
+      - attributions:
+          - 'Copyright (c) 2007 Free Software Foundation, Inc. <http://fsf.org/>'
+          - 'Copyright (c) 2009-2016 Stuart Knightley, David Duponchel, Franz Buchinger, Antonio Afonso'
+        license: MIT OR GPL-3.0-only
+        path: LICENSE.markdown
+      - license: MIT OR GPL-3.0-only
+        path: README.markdown
+      - attributions:
+          - (c) 1995-2013 Jean-loup Gailly and Mark Adler
+          - (c) 2014-2017 Vitaly Puzrin and Andrey Tupitsin
+          - (c) 2009-2016 Stuart Knightley <stuart at stuartk.com>
+        license: (MIT OR GPL-3.0-only) AND MIT AND Zlib
+        path: dist/jszip.js
+      - attributions:
+          - (c) 2009-2016 Stuart Knightley <stuart at stuartk.com>
+        license: MIT OR GPL-3.0-only
+        path: dist/jszip.min.js
+      - attributions:
+          - (c) 2009-2016 Stuart Knightley <stuart at stuartk.com>
+        license: MIT OR GPL-3.0-only
+        path: lib/license_header.js


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Incorrect SPDX Identifier

**Details:**
1. Incorrect SPDX Identifier: In the following files, the discovered license is "GPL-3.0-only AND MIT", but it is actually dual licensed (OR) and not multi-licensed (AND).

**Resolution:**
Changed the SPDX expression of involved licenses to "MIT OR GPL-3.0-only".

**Affected definitions**:
- [jszip 265c959b1f15f8cd5ebe152154b88796e4a82f42](https://clearlydefined.io/definitions/git/github/stuk/jszip/265c959b1f15f8cd5ebe152154b88796e4a82f42/265c959b1f15f8cd5ebe152154b88796e4a82f42)