### PR TITLE
Missing SPDX Identifier

### DIFF
--- a/curations/git/github/stuk/jszip.yaml
+++ b/curations/git/github/stuk/jszip.yaml
@@ -1,0 +1,39 @@
+coordinates:
+  name: jszip
+  namespace: stuk
+  provider: github
+  type: git
+revisions:
+  265c959b1f15f8cd5ebe152154b88796e4a82f42:
+    files:
+      - license: MIT OR GPL-3.0-only
+        path: bower.json
+      - license: MIT OR GPL-3.0-only
+        path: component.json
+      - license: MIT OR GPL-3.0-only
+        path: index.html
+      - attributions:
+          - 'Copyright (c) 2007 Free Software Foundation, Inc. <http://fsf.org/>'
+          - 'Copyright (c) 2009-2016 Stuart Knightley, David Duponchel, Franz Buchinger, Antonio Afonso'
+        license: MIT OR GPL-3.0-only
+        path: LICENSE.markdown
+      - license: MIT OR GPL-3.0-only
+        path: README.markdown
+      - attributions:
+          - (c) 1995-2013 Jean-loup Gailly and Mark Adler
+          - (c) 2014-2017 Vitaly Puzrin and Andrey Tupitsin
+          - (c) 2009-2016 Stuart Knightley <stuart at stuartk.com>
+        license: (MIT OR GPL-3.0-only) AND MIT AND Zlib
+        path: dist/jszip.js
+      - attributions:
+          - (c) 2009-2016 Stuart Knightley <stuart at stuartk.com>
+        license: MIT OR GPL-3.0-only
+        path: dist/jszip.min.js
+      - attributions:
+          - (c) 2009-2016 Stuart Knightley <stuart at stuartk.com>
+        license: MIT OR GPL-3.0-only
+        path: lib/license_header.js
+      - license: MIT
+        path: test/jquery-1.8.3.min.js
+      - license: MIT
+        path: vendor/FileSaver.js


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing SPDX Identifier

**Details:**
In the following files, there was no discovered license, however the source code file itself (either directly or indirectly via a link to license information) says that it is distributed under MIT License.
* https://github.com/Stuk/jszip/blob/265c959b1f15f8cd5ebe152154b88796e4a82f42/vendor/FileSaver

**Resolution:**
Changed the SPDX license expression to "MIT".

**Affected definitions**:
- [jszip 265c959b1f15f8cd5ebe152154b88796e4a82f42](https://clearlydefined.io/definitions/git/github/stuk/jszip/265c959b1f15f8cd5ebe152154b88796e4a82f42/265c959b1f15f8cd5ebe152154b88796e4a82f42)