### PR TITLE
File-level correction for missing SPDX Expression

### DIFF
--- a/curations/git/github/rnorth/visible-assertions.yaml
+++ b/curations/git/github/rnorth/visible-assertions.yaml
@@ -1,0 +1,10 @@
+coordinates:
+  name: visible-assertions
+  namespace: rnorth
+  provider: github
+  type: git
+revisions:
+  1e31bd9f2b5c55bad97fb73fb5dff25657a2206a:
+    files:
+      - license: MIT
+        path: pom.xml


### PR DESCRIPTION

**Type:** Missing

**Summary:**
File-level correction for missing SPDX Expression

**Details:**
In https://github.com/rnorth/visible-assertions/blob/17d67bd83a3500d99ac0220e0697da7a2c87a701/pom.xml, it is mentioned that "Visible Assertions" is under MIT License. But, as per ClearlyDefined, the SPDX Expression for the license is missing.

**Resolution:**
Changed the SPDX Expression of license to "MIT".

**Affected definitions**:
- [visible-assertions 1e31bd9f2b5c55bad97fb73fb5dff25657a2206a](https://clearlydefined.io/definitions/git/github/rnorth/visible-assertions/1e31bd9f2b5c55bad97fb73fb5dff25657a2206a/1e31bd9f2b5c55bad97fb73fb5dff25657a2206a)