### PR TITLE
MapSuiteDesktopForWinForms-BareBone 10.6.13

### DIFF
--- a/curations/nuget/nuget/-/mapsuitedesktopforwinforms-barebone.yaml
+++ b/curations/nuget/nuget/-/mapsuitedesktopforwinforms-barebone.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: mapsuitedesktopforwinforms-barebone
+  provider: nuget
+  type: nuget
+revisions:
+  10.6.13:
+    licensed:
+      declared: Other


### PR DESCRIPTION
Type: Missing

Summary:
MapSuiteDesktopForWinForms-BareBone 10.6.13

Details:
Add Other License

Resolution:
License Url:
http://wiki.thinkgeo.com/wiki/map_suite_license_agreement

Description:
The license is declared in NuGet website here. https://www.nuget.org/packages/MapSuiteDesktopForWinForms-BareBone

Affected definitions:

mapsuitedesktopforwinforms-barebone 10.6.13