### PR TITLE
License is missing

### DIFF
--- a/curations/pypi/pypi/-/typing-extensions.yaml
+++ b/curations/pypi/pypi/-/typing-extensions.yaml
@@ -6,3 +6,6 @@ revisions:
   3.7.4.3:
     licensed:
       declared: Python-2.0
+  4.3.0:
+    licensed:
+      declared: PSF-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
License is missing

**Details:**
You could find the license file here.

**Resolution:**
https://github.com/python/typing_extensions/blob/main/LICENSE

**Affected definitions**:
- [typing-extensions 4.3.0](https://clearlydefined.io/definitions/pypi/pypi/-/typing-extensions/4.3.0/4.3.0)