### PR TITLE
com.datadoghq:dd-sdk-android-gradle-plugin 1.15.0

### DIFF
--- a/curations/maven/gradleplugin/com.datadoghq/dd-sdk-android-gradle-plugin.yaml
+++ b/curations/maven/gradleplugin/com.datadoghq/dd-sdk-android-gradle-plugin.yaml
@@ -1,0 +1,9 @@
+coordinates:
+    name: dd-sdk-android-gradle-plugin
+    namespace: com.datadoghq
+    provider: gradleplugin
+    type: maven
+revisions:
+    1.15.0:
+        licensed:
+            declared: Apache-2.0


### PR DESCRIPTION
Type: Missing

Summary:
com.datadoghq:dd-sdk-android-gradle-plugin 1.15.0

Details:
Add Apache-2.0 License

Resolution:
License Url:
https://test.com

Description:
Google Maven Repository:
https://test.com

Pull request generated by @mpcen 

Affected definitions:

test