### PR TITLE
[TEST]Missing declared license and release date

### DIFF
--- a/curations/nuget/nuget/-/SampleDependency.yaml
+++ b/curations/nuget/nuget/-/SampleDependency.yaml
@@ -1,0 +1,15 @@
+coordinates:
+  name: SampleDependency
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0:
+    described:
+      facets:
+        doc:
+          - /docs/*
+        tests:
+          - /tests/*
+      releaseDate: '2014-10-27'
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
[TEST]Missing declared license and release date

**Details:**
The declared license and release date are both missing.

**Resolution:**
Found the declared license is MIT, see the location here in project [PATH TO LICENSE.MD]. The release date is indicated on the Nuget entry.

**Affected definitions**:
- [SampleDependency 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/SampleDependency/1.0.0/1.0.0)