### PR TITLE
Revert "test maven/mavencentral/org.apache.httpcomponents/httpcore/4.4.16"

### DIFF
--- a/curations/maven/mavencentral/org.apache.httpcomponents/httpcore.yaml
+++ b/curations/maven/mavencentral/org.apache.httpcomponents/httpcore.yaml
@@ -1,9 +1,0 @@
-coordinates:
-  name: httpcore
-  namespace: org.apache.httpcomponents
-  provider: mavencentral
-  type: maven
-revisions:
-  4.4.16:
-    described:
-      releaseDate: '2025-01-20'


### PR DESCRIPTION
Reverts clearlydefined/curated-data-dev#1527.  

This is one of the components used in the integration test.  The curation broke the integration test.  See test [log](https://github.com/clearlydefined/operations/actions/runs/13264887396/job/37029783039#step:7:355)